### PR TITLE
install to PREFIX & allow linking with libbam.a

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,10 @@ ifndef ROOT
 ROOT = $(shell pwd)
 endif
 
+ifndef PREFIX
+PREFIX = $(ROOT)
+endif
+
 ifndef SMITHLAB_CPP
 SMITHLAB_CPP=$(ROOT)/smithlab_cpp/
 endif
@@ -91,8 +95,8 @@ endif
 	$(CXX) $(CXXFLAGS) -o $@ $^ $(INCLUDEARGS) $(LIBS)
 
 install: $(PROGS)
-	@mkdir -p $(ROOT)/bin
-	@install -m 755 $(PROGS) $(ROOT)/bin
+	@mkdir -p $(PREFIX)/bin
+	@install -m 755 $(PROGS) $(PREFIX)/bin
 
 clean:
 	@-rm -f $(PROGS) *.o *~

--- a/Makefile
+++ b/Makefile
@@ -83,10 +83,17 @@ $(PROGS): $(addprefix $(SMITHLAB_CPP)/, \
 preseq: continued_fraction.o load_data_for_complexity.o moment_sequence.o
 
 ifdef SAMTOOLS_DIR
+ifdef LIBBAM
+LIBS += -pthread
+bam2mr preseq: $(addprefix $(SMITHLAB_CPP)/, SAM.o) \
+        $(LIBBAM)
+else
 bam2mr preseq: $(addprefix $(SMITHLAB_CPP)/, SAM.o) \
         $(addprefix $(SAMTOOLS_DIR)/, sam.o bam.o bam_import.o bam_pileup.o \
         faidx.o bam_aux.o kstring.o knetfile.o sam_header.o razf.o bgzf.o)
 endif
+endif # SAMTOOLS_DIR
+
 
 %.o: %.cpp %.hpp
 	$(CXX) $(CXXFLAGS) -c -o $@ $< $(INCLUDEARGS)


### PR DESCRIPTION
These two patches make it a little easier for packagers:

- `make install` will now install to `PREFIX/bin`, which defaults to `ROOT/bin` (as before)
- if `LIBBAM` is set to hold the path to libbam.a as created during the build of samtools, link against that library instead of compiling the bundled copy of samtools.

I have tested this with `libbam.a` from samtools 0.1.19 and it appears to work just fine.  The LIBBAM change was implemented as a response to https://github.com/smithlabcode/preseq/issues/14