### PR TITLE
use LDFLAGS to allow inclusion of libraries in non-standard locations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ endif # SAMTOOLS_DIR
 	$(CXX) $(CXXFLAGS) -c -o $@ $< $(INCLUDEARGS)
 
 %: %.cpp
-	$(CXX) $(CXXFLAGS) -o $@ $^ $(INCLUDEARGS) $(LIBS)
+	$(CXX) $(CXXFLAGS) -o $@ $^ $(INCLUDEARGS) $(LDFLAGS) $(LIBS)
 
 install: $(PROGS)
 	@mkdir -p $(PREFIX)/bin


### PR DESCRIPTION
For systems with modules in nonstandard locations, use LDFLAGS in the Makefile so libraries can be linked. This should have no effect for other users. 

For example, this will allow command line variables to be used instead of forcing custom Makefile modifications:
`make CXXFLAGS=-I/n/app/gsl/2.3/include/ LDFLAGS=-L/n/app/gsl/2.3/lib/`

