### PR TITLE
Add -B for BED input to gc_extrap

### DIFF
--- a/preseq.cpp
+++ b/preseq.cpp
@@ -909,7 +909,7 @@ gc_extrap(const int argc, const char **argv) {
                       false, orig_max_terms);
     opt_parse.add_opt("verbose", 'v', "print more information",
                       false, VERBOSE);
-    opt_parse.add_opt("bed", 'D',
+    opt_parse.add_opt("bed", 'B',
                       "input is in bed format without sequence information",
                       false, NO_SEQUENCE);
     opt_parse.add_opt("quick",'Q',


### PR DESCRIPTION
At the moment the -D switch on gc_extrap stands for both BED input and defect mode. No biggie, but it would be nice for them to have different representations. 

Thanks,
