### PR TITLE
Fixed compilation errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,12 +27,12 @@ PREFIX = $(ROOT)
 endif
 
 ifndef SMITHLAB_CPP
-SMITHLAB_CPP=$(ROOT)/smithlab_cpp/
+SMITHLAB_CPP=$(ROOT)/smithlab_cpp
 endif
 
 
 ifndef SAMTOOLS_DIR
-SAMTOOLS_DIR=$(ROOT)/samtools/
+SAMTOOLS_DIR=$(ROOT)/samtools
 endif
 
 SOURCES = $(wildcard *.cpp)
@@ -47,7 +47,7 @@ INCLUDEARGS = $(addprefix -I,$(INCLUDEDIRS))
 LIBS += -lgsl -lgslcblas -lz
 
 CXX = g++ 
-CXXFLAGS = -Wall -fPIC -fmessage-length=50
+CXXFLAGS = --std=c++11 -Wall -fPIC -fmessage-length=50
 
 # Flags for Mavericks
 ifeq "$(shell uname)" "Darwin"

--- a/load_data_for_complexity.cpp
+++ b/load_data_for_complexity.cpp
@@ -23,6 +23,11 @@
 #include <sstream>
 #include <unistd.h>
 
+#ifdef _WIN32
+  #include <unordered_map>
+#else
+  #include <tr1/unordered_map>
+#endif
 
 #include "GenomicRegion.hpp"
 #include "MappedRead.hpp"


### PR DESCRIPTION
I was having trouble getting preseq to compile (using g++ 5.4.0 on Ubuntu) -- these changes fixed the problem for me. I also needed to pull the smithlab_cpp project within the preseq directory after pulling preseq -- should there be a note about that in the README?

Thanks!